### PR TITLE
Add T6 to Supported Honeywell Devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,4 +49,5 @@ plugin allows you to access your Honeywell Home Device(s) from HomeKit with
 
 - [T9 Thermostat](https://www.resideo.com/us/en/products/air/thermostats/wifi-thermostats/t9-smart-thermostat-with-sensor-rcht9610wfsw2003-u/)
   - [T9 Smart Roomsensors](https://www.honeywellhome.com/us/en/products/air/thermostat-accessories/t9-smart-sensor-rchtsensor-1pk-u/)
+- [T6 Thermostat](https://getconnected.honeywellhome.com/en/t6)
 - [T5 Thermostat](https://www.resideo.com/us/en/products/air/thermostats/wifi-thermostats/t5-smart-thermostat-with-c-wire-adapter-rcht8612wf2005-u/)


### PR DESCRIPTION
As a result of the following issue we should add this information for new users.

https://github.com/donavanbecker/homebridge-honeywell-home/issues/416